### PR TITLE
Ensuring that tests are run against Ruby 2.5.x releases on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.3
+  - 2.5
 install: gem install 'geo_combine'


### PR DESCRIPTION
This ensures that test suites no longer break due to compatibility issues with older Ruby releases (please see https://travis-ci.org/OpenGeoMetadata/edu.nyu/builds/581842959)